### PR TITLE
Change license key setting input from password to text

### DIFF
--- a/includes/features/class-settings-page.php
+++ b/includes/features/class-settings-page.php
@@ -97,7 +97,7 @@ class Settings_Page {
 		]);
 
 		vrts()->settings()->add_setting([
-			'type' => 'password',
+			'type' => 'text',
 			'id' => 'vrts_license_key',
 			'section' => 'vrts-settings-section-general',
 			'title' => esc_html__( 'License Key', 'visual-regression-tests' ),


### PR DESCRIPTION
### Motivation
- Replace the masked `password` input type for the `vrts_license_key` setting with `text` to prevent browsers autofilling and overwriting the license key unintentionally.

### Description
- Updated the field `type` for `vrts_license_key` from `'password'` to `'text'` in `includes/features/class-settings-page.php`.

### Testing
- Ran `php -l` for syntax checks and the existing unit test suite via `vendor/bin/phpunit`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbcb45f7d883319dbda0b10c6b3f6f)